### PR TITLE
Implement authentication framework with Argon2, TOTP, and Passkey support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,3 +2,7 @@
 check-all = "clippy --all-features -- -D warnings"
 test-all  = "test --all-features"
 doc-all   = "doc --all-features --no-deps"
+# LCOV only (no % table — use `cov-report` after, or run `./scripts/cov-all.sh`).
+# Requires `cargo install cargo-llvm-cov` + `rustup component add llvm-tools-preview`.
+cov-all    = "llvm-cov --all-features --lcov --output-path lcov.info"
+cov-report = "llvm-cov report"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,8 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      issues: write
+      # lcov-reporter posts a commit comment (requires write); read is implied for checkout.
+      contents: write
       pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -115,7 +115,9 @@ jobs:
             echo "::error title=Line coverage below minimum::Workspace line coverage is ${LINE_PCT}% (${COVERED}/${TOTAL} lines) but CI requires at least ${MIN_LINE_COVERAGE_PERCENT}%. Add or extend tests for uncovered code under src/, then re-run cargo llvm-cov locally."
             exit 1
           fi
+      # Fork PRs get a read-only token — commit comments always 403; skip to keep the job green.
       - uses: romeovs/lcov-reporter-action@87a815f34ec27a5826abba44ce09bbc688da58fd # v0.4.0
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         with:
           lcov-file: lcov.info
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "asn1-rs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +98,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "base64urlsafedata"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,6 +119,15 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "block-buffer"
@@ -252,12 +279,16 @@ name = "ferrauth-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "argon2",
  "async-trait",
  "cargo-husky",
  "chrono",
  "openssl",
+ "password-hash",
+ "rand_core 0.6.4",
  "serde",
  "thiserror 2.0.18",
+ "tokio",
  "totp-rs",
  "tracing",
  "tracing-subscriber",
@@ -310,6 +341,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -694,6 +736,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,7 +841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -798,7 +851,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1052,6 +1114,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+dependencies = [
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "totp-rs"
 version = "5.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,6 +1249,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,18 @@ passkey = ["dep:webauthn-rs", "dep:openssl"]
 full    = ["totp", "passkey"]
 
 [dependencies]
-async-trait = "0.1"
-uuid        = { version = "1", features = ["v4", "serde"] }
-thiserror   = "2.0.18"
-anyhow      = "1"
-chrono      = { version = "0.4", features = ["serde"] }
-serde       = { version = "1", features = ["derive"] }
-zeroize     = { version = "1", features = ["derive"] }
-tracing     = "0.1"
+async-trait   = "0.1"
+argon2        = "0.5"
+password-hash = "0.5"
+rand_core     = { version = "0.6", features = ["getrandom"] }
+tokio         = { version = "1", features = ["macros", "rt-multi-thread"] }
+uuid          = { version = "1", features = ["v4", "serde"] }
+thiserror     = "2.0.18"
+anyhow        = "1"
+chrono        = { version = "0.4", features = ["serde"] }
+serde         = { version = "1", features = ["derive"] }
+zeroize       = { version = "1", features = ["derive"] }
+tracing       = "0.1"
 
 [dependencies.totp-rs]
 version  = "5"
@@ -42,6 +46,7 @@ version  = "0.5"
 optional = true
 
 [dev-dependencies]
+tokio              = { version = "1", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
 
 [dev-dependencies.cargo-husky]

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ cargo doc --all-features --no-deps --open
 
 **Security audits:** On **push/PR**, CI runs `rustsec/audit-check` and can post a **check** on the change. A **weekly** workflow (Mondays, UTC) runs plain **`cargo audit`** only — it does **not** open GitHub issues (least-privilege token); a **failed run** means the lockfile matches advisories you should address.
 
-**Coverage:** The **coverage** job enforces a **minimum line coverage** (currently **80%**). If it fails, the log and job summary print the measured percentage vs. the required minimum and an annotation explains that tests under `src/` need to cover more lines (run `cargo llvm-cov --all-features` locally to inspect).
+**Coverage:** The **coverage** job enforces a **minimum line coverage** (currently **80%**). If it fails, the log and job summary print the measured percentage vs. the required minimum and an annotation explains that tests under `src/` need to cover more lines. Locally, `cargo llvm-cov --all-features` prints a full **% table**; `cargo cov-all` only writes `lcov.info` (no table). Use **`./scripts/cov-all.sh`** for LCOV **and** the table, or run **`cargo cov-all && cargo cov-report`**.
 
 ### Run a single example
 

--- a/scripts/cov-all.sh
+++ b/scripts/cov-all.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# LCOV for local tools + same percentage table as plain `cargo llvm-cov` (CI only writes lcov).
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+cargo llvm-cov --all-features --lcov --output-path lcov.info
+exec cargo llvm-cov report

--- a/src/auth_method.rs
+++ b/src/auth_method.rs
@@ -1,0 +1,25 @@
+//! Coarse auth method labels for results and telemetry.
+
+/// Method used to authenticate (for [`crate::AuthResult`] and tracing).
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AuthMethod {
+    Password,
+    #[cfg(feature = "totp")]
+    Totp,
+    #[cfg(feature = "passkey")]
+    Passkey,
+}
+
+impl AuthMethod {
+    /// Stable label for tracing / logs (not a secret).
+    pub const fn as_label(self) -> &'static str {
+        match self {
+            AuthMethod::Password => "password",
+            #[cfg(feature = "totp")]
+            AuthMethod::Totp => "totp",
+            #[cfg(feature = "passkey")]
+            AuthMethod::Passkey => "passkey",
+        }
+    }
+}

--- a/src/auth_tracing.rs
+++ b/src/auth_tracing.rs
@@ -1,0 +1,27 @@
+//! Internal tracing helpers for auth verification (no credentials).
+
+use uuid::Uuid;
+
+use crate::AuthError;
+use crate::telemetry::{ATTR_AUTH_METHOD, ATTR_USER_ID};
+
+pub(crate) fn record_verify_user_id(user_id: &Uuid) {
+    tracing::Span::current().record(ATTR_USER_ID, tracing::field::display(user_id));
+}
+
+/// Successful verify: [`tracing::info!`] with standard field names (see [`crate::telemetry`]).
+pub(crate) fn log_verify_succeeded(user_id: &Uuid, auth_method_label: &'static str) {
+    tracing::info!(
+        { ATTR_USER_ID } = %user_id,
+        { ATTR_AUTH_METHOD } = %auth_method_label,
+        "authentication succeeded",
+    );
+}
+
+/// Failed verify: [`tracing::error!`] with error kind only ([`AuthError`]'s [`Display`](std::fmt::Display)).
+pub(crate) fn log_verify_failed(err: &AuthError) {
+    tracing::error!(
+        auth.error = %err,
+        "authentication failed",
+    );
+}

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -1,0 +1,79 @@
+//! Credential payloads for [`crate::AuthProvider::verify`].
+//!
+//! These types intentionally avoid [`Debug`] where they may hold secrets.
+
+use uuid::Uuid;
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+/// UTF-8 password as owned bytes; cleared on drop. Not [`Debug`] or [`Clone`].
+#[derive(Zeroize, ZeroizeOnDrop)]
+pub struct PlaintextPassword(Vec<u8>);
+
+impl PlaintextPassword {
+    /// Stores a copy of `password` in cleared-on-drop memory.
+    pub fn new(password: impl AsRef<[u8]>) -> Self {
+        Self(password.as_ref().to_vec())
+    }
+
+    pub(crate) fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+/// Argon2 password hash string (e.g. PHC). No [`Debug`] or [`Clone`] to reduce accidental leakage.
+pub struct PasswordHash(String);
+
+impl PasswordHash {
+    pub(crate) fn new(phc: String) -> Self {
+        Self(phc)
+    }
+
+    /// Wrap a PHC string loaded from storage (e.g. a database row).
+    pub fn from_phc(phc: impl Into<String>) -> Self {
+        Self(phc.into())
+    }
+
+    /// Borrow the PHC string for verification or persistence.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Raw TOTP secret (≥ 128 bits). Cleared on drop. Not [`Debug`] or [`Clone`].
+#[cfg(feature = "totp")]
+#[derive(Zeroize, ZeroizeOnDrop)]
+pub struct TotpSecret(Vec<u8>);
+
+#[cfg(feature = "totp")]
+impl TotpSecret {
+    /// Takes ownership of secret bytes; must meet minimum length for RFC 6238.
+    pub fn from_bytes(bytes: Vec<u8>) -> Result<Self, crate::AuthError> {
+        if bytes.len() < 16 {
+            return Err(crate::AuthError::Internal);
+        }
+        Ok(Self(bytes))
+    }
+
+    pub(crate) fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+/// Input bundle for [`crate::AuthProvider::verify`]. Not [`Debug`] — may contain secrets.
+pub enum Credentials {
+    Password {
+        user_id: Uuid,
+        password: PlaintextPassword,
+        hash: PasswordHash,
+    },
+    #[cfg(feature = "totp")]
+    Totp {
+        user_id: Uuid,
+        code: String,
+        secret: TotpSecret,
+    },
+    #[cfg(feature = "passkey")]
+    Passkey {
+        user_id: Uuid,
+    },
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,26 @@
+//! Authentication errors — safe [`Display`](std::fmt::Display) output only (no secrets).
+
+use thiserror::Error;
+
+/// Errors returned by [`crate::AuthProvider::verify`].
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum AuthError {
+    /// First-factor or combined credentials were rejected (no hint which part failed).
+    #[error("invalid credentials")]
+    InvalidCredentials,
+    /// Second factor is required before the session is fully authenticated.
+    #[error("mfa required")]
+    MfaRequired,
+    /// TOTP or similar MFA code was wrong or out of window.
+    #[error("invalid mfa code")]
+    InvalidMfaCode,
+    /// Session is no longer valid.
+    #[error("session expired")]
+    SessionExpired,
+    /// WebAuthn / passkey verification failed.
+    #[error("passkey verification failed")]
+    PasskeyVerificationFailed,
+    /// Unexpected failure (logged server-side; not shown to clients as distinct variants).
+    #[error("internal error")]
+    Internal,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,35 @@
-//! Crate root.
-//!
-//! TODO: Replace this placeholder with the actual public API
-//! and module layout as described in the crate's README.
+//! Pluggable authentication: password (always), optional TOTP and passkey providers.
 //!
 //! ## Tracing
 //!
-//! The [`telemetry`] module defines standard auth span attributes. This crate does **not**
-//! re-export [`tracing`]; install/set your own subscriber (e.g., via `tracing-subscriber`).
+//! [`AuthProvider::verify`] implementations emit `tracing` spans and events. Sensitive values are
+//! never passed into [`tracing::instrument`] fields — use [`telemetry`](crate::telemetry) attribute
+//! names only with coarse labels and ids.
 
 pub mod telemetry;
 
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn placeholder_test() {
-        // TODO: Add real tests for the crate's public API once it is defined.
-    }
-}
+mod auth_method;
+mod auth_tracing;
+mod credentials;
+mod error;
+mod password;
+mod provider;
+mod result;
+
+#[cfg(feature = "passkey")]
+mod passkey;
+#[cfg(feature = "totp")]
+mod totp;
+
+pub use auth_method::AuthMethod;
+#[cfg(feature = "totp")]
+pub use credentials::TotpSecret;
+pub use credentials::{Credentials, PasswordHash, PlaintextPassword};
+pub use error::AuthError;
+#[cfg(feature = "passkey")]
+pub use passkey::PasskeyAuth;
+pub use password::PasswordAuth;
+pub use provider::AuthProvider;
+pub use result::AuthResult;
+#[cfg(feature = "totp")]
+pub use totp::TotpAuth;

--- a/src/passkey.rs
+++ b/src/passkey.rs
@@ -1,0 +1,77 @@
+//! Passkey / WebAuthn provider shell (feature `passkey`).
+//!
+//! Full WebAuthn ceremonies use `webauthn-rs` begin/finish APIs. [`AuthProvider::verify`] is kept
+//! for a uniform trait surface; direct passkey login should use those flows.
+
+use async_trait::async_trait;
+
+use crate::auth_method::AuthMethod;
+use crate::auth_tracing;
+use crate::credentials::Credentials;
+use crate::error::AuthError;
+use crate::provider::AuthProvider;
+use crate::result::AuthResult;
+use crate::telemetry::{ATTR_AUTH_METHOD, ATTR_USER_ID};
+
+/// Passkey authentication provider (placeholder `verify` — use WebAuthn ceremony APIs in production).
+#[derive(Debug, Clone)]
+pub struct PasskeyAuth {
+    rp_id: String,
+    rp_name: String,
+}
+
+impl PasskeyAuth {
+    /// Configure relying party id and display name for future WebAuthn operations.
+    pub fn new(rp_id: &str, rp_name: &str) -> Result<Self, AuthError> {
+        if rp_id.is_empty() || rp_name.is_empty() {
+            return Err(AuthError::Internal);
+        }
+        Ok(Self { rp_id: rp_id.to_string(), rp_name: rp_name.to_string() })
+    }
+
+    /// Relying party id (e.g. registrable domain suffix) configured at construction.
+    pub fn rp_id(&self) -> &str {
+        &self.rp_id
+    }
+
+    /// Human-readable RP name shown in WebAuthn UI.
+    pub fn rp_name(&self) -> &str {
+        &self.rp_name
+    }
+}
+
+/// Sync core so line coverage maps to this file (`async_trait` bodies are often invisible to llvm-cov).
+pub(crate) fn verify_passkey_credentials(
+    credentials: Credentials,
+) -> Result<AuthResult, AuthError> {
+    let Credentials::Passkey { user_id } = credentials else {
+        let err = AuthError::InvalidCredentials;
+        auth_tracing::log_verify_failed(&err);
+        return Err(err);
+    };
+
+    auth_tracing::record_verify_user_id(&user_id);
+
+    let err = AuthError::PasskeyVerificationFailed;
+    auth_tracing::log_verify_failed(&err);
+    Err(err)
+}
+
+#[async_trait]
+impl AuthProvider for PasskeyAuth {
+    #[tracing::instrument(
+        name = "PasskeyAuth::verify",
+        skip_all,
+        fields(
+            { ATTR_AUTH_METHOD } = %"passkey",
+            { ATTR_USER_ID } = tracing::field::Empty,
+        ),
+    )]
+    async fn verify(&self, credentials: Credentials) -> Result<AuthResult, AuthError> {
+        verify_passkey_credentials(credentials)
+    }
+
+    fn method(&self) -> AuthMethod {
+        AuthMethod::Passkey
+    }
+}

--- a/src/password.rs
+++ b/src/password.rs
@@ -1,0 +1,93 @@
+//! Password authentication via Argon2 (CPU work on a blocking thread).
+
+use argon2::Argon2;
+use argon2::password_hash::rand_core::OsRng;
+use argon2::password_hash::{
+    PasswordHash as PhcHash, PasswordHasher, PasswordVerifier, SaltString,
+};
+use async_trait::async_trait;
+
+use crate::auth_method::AuthMethod;
+use crate::auth_tracing;
+use crate::credentials::{Credentials, PasswordHash, PlaintextPassword};
+use crate::error::AuthError;
+use crate::provider::AuthProvider;
+use crate::result::AuthResult;
+use crate::telemetry::{ATTR_AUTH_METHOD, ATTR_USER_ID};
+
+/// Argon2 password provider.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PasswordAuth;
+
+impl PasswordAuth {
+    /// Hash a password for storage (e.g. at registration). Runs on the calling thread.
+    pub fn hash_password(password: &PlaintextPassword) -> Result<PasswordHash, AuthError> {
+        let salt = SaltString::generate(&mut OsRng);
+        let argon2 = Argon2::default();
+        let hash = argon2
+            .hash_password(password.as_slice(), &salt)
+            .map_err(|_| AuthError::Internal)?
+            .to_string();
+        Ok(PasswordHash::new(hash))
+    }
+}
+
+fn verify_password_blocking(password: PlaintextPassword, hash: String) -> Result<(), AuthError> {
+    let parsed = PhcHash::new(&hash).map_err(|_| AuthError::Internal)?;
+    Argon2::default()
+        .verify_password(password.as_slice(), &parsed)
+        .map_err(|_| AuthError::InvalidCredentials)?;
+    Ok(())
+}
+
+#[async_trait]
+impl AuthProvider for PasswordAuth {
+    #[tracing::instrument(
+        name = "PasswordAuth::verify",
+        skip_all,
+        fields(
+            { ATTR_AUTH_METHOD } = %"password",
+            { ATTR_USER_ID } = tracing::field::Empty,
+        ),
+    )]
+    async fn verify(&self, credentials: Credentials) -> Result<AuthResult, AuthError> {
+        let (user_id, password, hash) = match credentials {
+            Credentials::Password { user_id, password, hash } => (user_id, password, hash),
+            #[cfg(any(feature = "totp", feature = "passkey"))]
+            _ => {
+                let err = AuthError::InvalidCredentials;
+                auth_tracing::log_verify_failed(&err);
+                return Err(err);
+            }
+        };
+
+        auth_tracing::record_verify_user_id(&user_id);
+        let hash_str = hash.as_str().to_string();
+
+        let verify =
+            tokio::task::spawn_blocking(move || verify_password_blocking(password, hash_str))
+                .await
+                .map_err(|_| AuthError::Internal);
+
+        match verify {
+            Ok(Ok(())) => {
+                let result = AuthResult { user_id, method: AuthMethod::Password };
+                auth_tracing::log_verify_succeeded(&user_id, AuthMethod::Password.as_label());
+                Ok(result)
+            }
+            Ok(Err(err)) => {
+                auth_tracing::log_verify_failed(&err);
+                Err(err)
+            }
+            Err(_) => {
+                let err = AuthError::Internal;
+                auth_tracing::log_verify_failed(&err);
+                Err(err)
+            }
+        }
+    }
+
+    fn method(&self) -> AuthMethod {
+        AuthMethod::Password
+    }
+}

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -1,0 +1,18 @@
+//! [`AuthProvider`] trait.
+
+use async_trait::async_trait;
+
+use crate::auth_method::AuthMethod;
+use crate::credentials::Credentials;
+use crate::error::AuthError;
+use crate::result::AuthResult;
+
+/// Pluggable authentication (password, TOTP, passkey, …).
+#[async_trait]
+pub trait AuthProvider: Send + Sync {
+    /// Verify credentials and return the authenticated subject.
+    async fn verify(&self, credentials: Credentials) -> Result<AuthResult, AuthError>;
+
+    /// Which [`AuthMethod`] this provider represents.
+    fn method(&self) -> AuthMethod;
+}

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,0 +1,12 @@
+//! Successful authentication outcome.
+
+use uuid::Uuid;
+
+use crate::auth_method::AuthMethod;
+
+/// Returned when [`crate::AuthProvider::verify`] succeeds.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthResult {
+    pub user_id: Uuid,
+    pub method: AuthMethod,
+}

--- a/src/totp.rs
+++ b/src/totp.rs
@@ -1,0 +1,60 @@
+//! TOTP verification (feature `totp`).
+
+use async_trait::async_trait;
+use totp_rs::{Algorithm, TOTP};
+
+use crate::auth_method::AuthMethod;
+use crate::auth_tracing;
+use crate::credentials::Credentials;
+use crate::error::AuthError;
+use crate::provider::AuthProvider;
+use crate::result::AuthResult;
+use crate::telemetry::{ATTR_AUTH_METHOD, ATTR_USER_ID};
+
+/// Time-based one-time password provider (RFC 6238).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct TotpAuth;
+
+/// Sync core so line coverage maps to this file (`async_trait` bodies are often invisible to llvm-cov).
+pub(crate) fn verify_totp_credentials(credentials: Credentials) -> Result<AuthResult, AuthError> {
+    let Credentials::Totp { user_id, code, secret } = credentials else {
+        let err = AuthError::InvalidCredentials;
+        auth_tracing::log_verify_failed(&err);
+        return Err(err);
+    };
+
+    auth_tracing::record_verify_user_id(&user_id);
+
+    let totp = TOTP::new(Algorithm::SHA1, 6, 1, 30, secret.as_slice().to_vec())
+        .map_err(|_| AuthError::Internal)?;
+
+    let ok = totp.check_current(code.trim()).map_err(|_| AuthError::Internal)?;
+
+    if !ok {
+        let err = AuthError::InvalidMfaCode;
+        auth_tracing::log_verify_failed(&err);
+        return Err(err);
+    }
+
+    auth_tracing::log_verify_succeeded(&user_id, AuthMethod::Totp.as_label());
+    Ok(AuthResult { user_id, method: AuthMethod::Totp })
+}
+
+#[async_trait]
+impl AuthProvider for TotpAuth {
+    #[tracing::instrument(
+        name = "TotpAuth::verify",
+        skip_all,
+        fields(
+            { ATTR_AUTH_METHOD } = %"totp",
+            { ATTR_USER_ID } = tracing::field::Empty,
+        ),
+    )]
+    async fn verify(&self, credentials: Credentials) -> Result<AuthResult, AuthError> {
+        verify_totp_credentials(credentials)
+    }
+
+    fn method(&self) -> AuthMethod {
+        AuthMethod::Totp
+    }
+}

--- a/tests/auth_verify_tracing.rs
+++ b/tests/auth_verify_tracing.rs
@@ -1,0 +1,280 @@
+//! Ensures [`AuthProvider::verify`] tracing does not record passwords, TOTP secrets, or codes.
+
+use std::sync::{Arc, Mutex};
+
+use ferrauth_core::telemetry::{ATTR_AUTH_METHOD, ATTR_USER_ID};
+use ferrauth_core::{
+    AuthError, AuthMethod, AuthProvider, AuthResult, Credentials, PasswordAuth, PasswordHash,
+    PlaintextPassword,
+};
+use tracing::Subscriber;
+use tracing::field::{Field, Visit};
+use tracing::span::{Attributes, Record};
+use tracing_subscriber::Registry;
+use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
+use tracing_subscriber::registry::LookupSpan;
+use uuid::Uuid;
+
+#[cfg(feature = "passkey")]
+use ferrauth_core::PasskeyAuth;
+#[cfg(feature = "totp")]
+use ferrauth_core::{TotpAuth, TotpSecret};
+#[cfg(feature = "totp")]
+use totp_rs::{Algorithm, TOTP};
+
+#[derive(Default, Clone)]
+struct Captured(Arc<Mutex<Vec<(String, String)>>>);
+
+#[derive(Default)]
+struct RecordVisitor {
+    pairs: Vec<(String, String)>,
+}
+
+impl Visit for RecordVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.pairs.push((field.name().to_string(), format!("{value:?}")));
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.pairs.push((field.name().to_string(), value.to_string()));
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.pairs.push((field.name().to_string(), format!("{value}")));
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.pairs.push((field.name().to_string(), format!("{value}")));
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.pairs.push((field.name().to_string(), format!("{value}")));
+    }
+
+    fn record_i128(&mut self, field: &Field, value: i128) {
+        self.pairs.push((field.name().to_string(), format!("{value}")));
+    }
+
+    fn record_u128(&mut self, field: &Field, value: u128) {
+        self.pairs.push((field.name().to_string(), format!("{value}")));
+    }
+
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.pairs.push((field.name().to_string(), format!("{value}")));
+    }
+}
+
+struct AllFieldsLayer(Captured);
+
+impl<S> Layer<S> for AllFieldsLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, _id: &tracing::span::Id, _ctx: Context<'_, S>) {
+        let mut visitor = RecordVisitor::default();
+        attrs.record(&mut visitor);
+        self.0.0.lock().expect("lock poisoned").extend(visitor.pairs);
+    }
+
+    fn on_record(&self, _span: &tracing::span::Id, values: &Record<'_>, _ctx: Context<'_, S>) {
+        let mut visitor = RecordVisitor::default();
+        values.record(&mut visitor);
+        self.0.0.lock().expect("lock poisoned").extend(visitor.pairs);
+    }
+
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        let mut visitor = RecordVisitor::default();
+        event.record(&mut visitor);
+        let mut lock = self.0.0.lock().expect("lock poisoned");
+        lock.extend(visitor.pairs);
+        lock.push(("event.name".to_string(), event.metadata().name().to_string()));
+    }
+}
+
+fn captured_dump(c: &Captured) -> String {
+    let lock = c.0.lock().expect("lock poisoned");
+    lock.iter().map(|(k, v)| format!("{k}={v}")).collect::<Vec<_>>().join("\n")
+}
+
+fn clear(c: &Captured) {
+    c.0.lock().expect("lock poisoned").clear();
+}
+
+/// Known password — must never appear in tracing field values or event metadata we collect.
+const PLAINTEXT_PASSWORD: &str = "CorrectHorseBatteryStaple-TracingTest-99!";
+
+#[tokio::test]
+async fn password_verify_never_records_plaintext_in_tracing() {
+    let captured = Captured::default();
+    let subscriber = Registry::default().with(AllFieldsLayer(captured.clone()));
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let user_id = Uuid::new_v4();
+    let hash =
+        PasswordAuth::hash_password(&PlaintextPassword::new(PLAINTEXT_PASSWORD)).expect("hash");
+
+    let wrong = PlaintextPassword::new("wrong-password-not-the-secret");
+    let creds = Credentials::Password {
+        user_id,
+        password: wrong,
+        hash: PasswordHash::from_phc(hash.as_str()),
+    };
+    let err = PasswordAuth.verify(creds).await.expect_err("wrong password");
+    assert_eq!(err, AuthError::InvalidCredentials);
+    let dump = captured_dump(&captured);
+    assert!(
+        !dump.contains(PLAINTEXT_PASSWORD),
+        "tracing must not contain plaintext password (failure path): {dump}"
+    );
+    clear(&captured);
+
+    let creds_ok = Credentials::Password {
+        user_id,
+        password: PlaintextPassword::new(PLAINTEXT_PASSWORD),
+        hash: PasswordHash::from_phc(hash.as_str()),
+    };
+    let result = PasswordAuth.verify(creds_ok).await.expect("verify");
+    assert_eq!(result, AuthResult { user_id, method: AuthMethod::Password });
+    let dump = captured_dump(&captured);
+    assert!(
+        !dump.contains(PLAINTEXT_PASSWORD),
+        "tracing must not contain plaintext password (success path): {dump}"
+    );
+    assert!(
+        dump.contains(ATTR_AUTH_METHOD) && dump.contains("password"),
+        "expected auth.method label in trace: {dump}"
+    );
+    assert!(
+        dump.contains(ATTR_USER_ID) && dump.contains(&user_id.to_string()),
+        "expected user.id in trace: {dump}"
+    );
+}
+
+#[cfg(feature = "totp")]
+#[test]
+fn totp_method_is_totp() {
+    assert_eq!(TotpAuth.method(), AuthMethod::Totp);
+}
+
+#[cfg(feature = "totp")]
+#[tokio::test]
+async fn totp_rejects_password_credentials() {
+    let user_id = Uuid::new_v4();
+    let hash =
+        PasswordAuth::hash_password(&PlaintextPassword::new("totp-cross-test")).expect("hash");
+    let creds = Credentials::Password {
+        user_id,
+        password: PlaintextPassword::new("totp-cross-test"),
+        hash,
+    };
+    assert_eq!(
+        TotpAuth.verify(creds).await.expect_err("wrong variant"),
+        AuthError::InvalidCredentials
+    );
+}
+
+#[cfg(feature = "totp")]
+#[tokio::test]
+async fn totp_rejects_wrong_code() {
+    let user_id = Uuid::new_v4();
+    let raw = [0x3Cu8; 20];
+    let secret = TotpSecret::from_bytes(raw.to_vec()).expect("secret");
+    let creds = Credentials::Totp { user_id, code: "000000".to_string(), secret };
+    assert_eq!(TotpAuth.verify(creds).await.expect_err("bad code"), AuthError::InvalidMfaCode);
+}
+
+#[cfg(all(feature = "totp", feature = "passkey"))]
+#[tokio::test]
+async fn totp_rejects_passkey_credentials() {
+    let creds = Credentials::Passkey { user_id: Uuid::nil() };
+    assert_eq!(
+        TotpAuth.verify(creds).await.expect_err("wrong variant"),
+        AuthError::InvalidCredentials
+    );
+}
+
+#[cfg(feature = "totp")]
+#[tokio::test]
+async fn totp_verify_never_records_secret_or_code_in_tracing() {
+    let captured = Captured::default();
+    let subscriber = Registry::default().with(AllFieldsLayer(captured.clone()));
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let user_id = Uuid::new_v4();
+    let raw = [0x5Au8; 20];
+    let secret = TotpSecret::from_bytes(raw.to_vec()).expect("secret length");
+    let device = TOTP::new(Algorithm::SHA1, 6, 1, 30, raw.to_vec()).expect("totp");
+    let code = device.generate_current().expect("code");
+
+    assert!(!code.is_empty(), "generated TOTP code must be non-empty for this test");
+
+    let creds = Credentials::Totp { user_id, code: code.clone(), secret };
+    TotpAuth.verify(creds).await.expect("totp ok");
+
+    let dump = captured_dump(&captured);
+    assert!(!dump.contains(&code), "TOTP code must not appear in tracing output: {dump}");
+    let secret_b32 = device.get_secret_base32();
+    assert!(!dump.contains(&secret_b32), "TOTP secret (base32) must not appear in tracing: {dump}");
+}
+
+#[cfg(feature = "passkey")]
+#[test]
+fn passkey_auth_method_label_is_stable() {
+    assert_eq!(AuthMethod::Passkey.as_label(), "passkey");
+}
+
+#[cfg(feature = "passkey")]
+#[test]
+fn passkey_method_and_rp_accessors() {
+    let auth = PasskeyAuth::new("login.example.com", "Example App").expect("new");
+    assert_eq!(auth.method(), AuthMethod::Passkey);
+    assert_eq!(auth.rp_id(), "login.example.com");
+    assert_eq!(auth.rp_name(), "Example App");
+}
+
+#[cfg(feature = "passkey")]
+#[test]
+fn passkey_new_rejects_empty_rp_id_or_name() {
+    assert_eq!(PasskeyAuth::new("", "Name").expect_err("empty rp_id"), AuthError::Internal);
+    assert_eq!(PasskeyAuth::new("id.example", "").expect_err("empty rp_name"), AuthError::Internal);
+}
+
+#[cfg(feature = "passkey")]
+#[tokio::test]
+async fn passkey_rejects_password_credentials() {
+    let auth = PasskeyAuth::new("a.example", "A").expect("new");
+    let user_id = Uuid::new_v4();
+    let hash = PasswordAuth::hash_password(&PlaintextPassword::new("pk-cross")).expect("hash");
+    let creds =
+        Credentials::Password { user_id, password: PlaintextPassword::new("pk-cross"), hash };
+    assert_eq!(auth.verify(creds).await.expect_err("wrong variant"), AuthError::InvalidCredentials);
+}
+
+#[cfg(all(feature = "totp", feature = "passkey"))]
+#[tokio::test]
+async fn passkey_rejects_totp_credentials() {
+    let auth = PasskeyAuth::new("a.example", "A").expect("new");
+    let raw = [7u8; 20];
+    let secret = TotpSecret::from_bytes(raw.to_vec()).expect("secret");
+    let creds = Credentials::Totp { user_id: Uuid::nil(), code: "123456".to_string(), secret };
+    assert_eq!(auth.verify(creds).await.expect_err("wrong variant"), AuthError::InvalidCredentials);
+}
+
+#[cfg(feature = "passkey")]
+#[tokio::test]
+async fn passkey_verify_is_instrumented_without_extra_panic() {
+    let captured = Captured::default();
+    let subscriber = Registry::default().with(AllFieldsLayer(captured.clone()));
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let auth = PasskeyAuth::new("example.com", "Example").expect("passkey new");
+    let user_id = Uuid::new_v4();
+    let creds = Credentials::Passkey { user_id };
+    let err = auth.verify(creds).await.expect_err("stub verify fails");
+    assert_eq!(err, AuthError::PasskeyVerificationFailed);
+    let dump = captured_dump(&captured);
+    assert!(
+        dump.contains("passkey") || dump.contains("PasskeyAuth"),
+        "expected passkey-related trace: {dump}"
+    );
+}


### PR DESCRIPTION
- Introduced a new authentication framework in `src/` with modules for password, TOTP, and passkey authentication.
- Added `AuthProvider` trait for pluggable authentication methods, allowing for extensibility.
- Implemented `PasswordAuth` using Argon2 for secure password hashing and verification.
- Created `TotpAuth` for time-based one-time password verification, adhering to RFC 6238.
- Developed `PasskeyAuth` for WebAuthn integration, providing a placeholder for future implementation.
- Added telemetry support for tracing authentication flows without exposing sensitive information.
- Updated `Cargo.toml` to include new dependencies for Argon2 and TOTP functionality.
- Enhanced CI with coverage reporting and tests to ensure robust authentication handling.